### PR TITLE
feat(sankhya): add GitLab project annotations

### DIFF
--- a/components/ecs-sankhya.yaml
+++ b/components/ecs-sankhya.yaml
@@ -6,6 +6,8 @@ metadata:
   description: Serviço responsável pelo processamento financeiro e faturamento
   annotations:
     aws.amazon.com/amazon-ecs-service-arn: "arn:aws:ecs:us-east-1:904233116513:service/sankhya-demo/financial-api"
+    gitlab.com/project-slug: "Elesiann/financial-api"
+    gitlab.com/project-id: "82340956"
   tags:
     - java
     - ecs
@@ -24,6 +26,8 @@ metadata:
   description: Gerenciamento de pedidos e fluxo de vendas
   annotations:
     aws.amazon.com/amazon-ecs-service-arn: "arn:aws:ecs:us-east-1:904233116513:service/sankhya-demo/order-service"
+    gitlab.com/project-slug: "Elesiann/order-service"
+    gitlab.com/project-id: "82340960"
   tags:
     - java
     - ecs
@@ -42,6 +46,8 @@ metadata:
   description: Gateway de integração com sistemas externos e ERPs parceiros
   annotations:
     aws.amazon.com/amazon-ecs-service-arn: "arn:aws:ecs:us-east-1:904233116513:service/sankhya-demo/integration-gateway"
+    gitlab.com/project-slug: "Elesiann/integration-gateway"
+    gitlab.com/project-id: "82340963"
   tags:
     - gateway
     - ecs


### PR DESCRIPTION
## Summary

Wires the 3 sankhya-demo services to their GitLab CI projects on gitlab.com (Elesiann/demo account) so the DevPortal GitLab plugin can surface pipelines + MR + issue data on each entity page.

| Component | GitLab project | ID |
|---|---|---|
| financial-api | Elesiann/financial-api | 82340956 |
| order-service | Elesiann/order-service | 82340960 |
| integration-gateway | Elesiann/integration-gateway | 82340963 |

## Context

Part of the Sankhya demo Day 2 buildout — pairs with the GitLab plugin workspace bump in \`devportal-plugin-export-overlays#18\`. Each GitLab project has a sample \`.gitlab-ci.yml\` with 3 stages (build, test, deploy) so the entity tab shows multi-stage pipeline visualization.

## Test plan

- [ ] After the DevPortal Sankhya instance picks up the new annotations, open the financial-api entity in the portal
- [ ] Confirm GitLab tab renders with pipeline list (status visible even if jobs are pending due to free-tier runner verification)
- [ ] Same for order-service and integration-gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)