### PR TITLE
feat(sankhya): add GitLab project annotation to integration-gateway

### DIFF
--- a/components/ecs-sankhya.yaml
+++ b/components/ecs-sankhya.yaml
@@ -42,6 +42,7 @@ metadata:
   description: Gateway de integração com sistemas externos e ERPs parceiros
   annotations:
     aws.amazon.com/amazon-ecs-service-arn: "arn:aws:ecs:us-east-1:904233116513:service/sankhya-demo/integration-gateway"
+    gitlab.com/project-slug: Elesiann/integration-gateway
   tags:
     - gateway
     - ecs


### PR DESCRIPTION
Maps the `integration-gateway` component to its GitLab CI project (`Elesiann/integration-gateway`) via the `gitlab.com/project-slug` annotation, so the GitLab plugin's pipelines tab and overview cards render on the entity page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)